### PR TITLE
chore: add safe type hints for constants and returns in generate_proxy_list.py

### DIFF
--- a/generate_proxy_list.py
+++ b/generate_proxy_list.py
@@ -60,7 +60,7 @@ class ProxyListScraper:
             print(f"抓取错误: {e}")
             return []
     
-    def save_to_file(self, proxies, filename='proxy.txt'):
+    def save_to_file(self, proxies, filename: str='proxy.txt') -> bool:
         """保存代理列表到文件"""
         try:
             with open(filename, 'w', encoding='utf-8') as f:
@@ -79,7 +79,7 @@ class ProxyListScraper:
             print(f"保存文件错误: {e}")
             return False
 
-def main():
+def main() -> None:
     """主函数"""
     scraper = ProxyListScraper()
     


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be slightly improved. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Type hint additions
- `generate_proxy_list.py`: added type hints to 2 function(s)

I have added **strictly conservative** type annotations based only on explicit primitive default values and singular return statements. Complex objects and dynamic references were purposefully ignored to avoid false positives.

### Examples of changes
**Example change in `generate_proxy_list.py`:**
```diff
-    def save_to_file(self, proxies, filename='proxy.txt'):
+    def save_to_file(self, proxies, filename: str='proxy.txt') -> bool:
-def main():
+def main() -> None:
```

---
### Verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- I did not modify any `__init__.py` files.

If anything looks incorrect, please feel free to adjust it or close the PR entirely. Thank you for maintaining this project!